### PR TITLE
Removed dependency on bignum, switched to native BigInt

### DIFF
--- a/lib/hash.dart
+++ b/lib/hash.dart
@@ -89,6 +89,8 @@ class _HashBase implements Hash {
       content = CryptoUtils.hexToBytes(content);
     else if (content is! BigInt)  
       content = content.toByteArray();
+    else // BigInt
+      content = CryptoUtils.bigIntToByteArray(content);
     // store as bytes
     if (content is TypedData)
       _content = new Uint8List.fromList(content.buffer

--- a/lib/hash.dart
+++ b/lib/hash.dart
@@ -2,7 +2,6 @@ library cryptoutils.hash;
 
 import "dart:typed_data";
 
-import "package:bignum/bignum.dart";
 import "package:collection/collection.dart" show ListEquality;
 
 import "package:cryptoutils/utils.dart";
@@ -38,7 +37,7 @@ abstract class Hash implements TypedData {
   /**
    * The hash value as a Big Integer.
    */
-  BigInteger asBigInteger();
+  BigInt asBigInteger();
 
   /**
    * Copy this hash value as a byte list.
@@ -48,7 +47,7 @@ abstract class Hash implements TypedData {
   /**
    * Copy this hash value as a Big Integer.
    */
-  BigInteger copyAsBigInteger();
+  BigInt copyAsBigInteger();
 
   /**
    * Hexadecimal representation of this hash value.
@@ -88,7 +87,7 @@ class _HashBase implements Hash {
     // convert
     if (content is String)
       content = CryptoUtils.hexToBytes(content);
-    else if (content is BigInteger)
+    else if (content is! BigInt)  
       content = content.toByteArray();
     // store as bytes
     if (content is TypedData)
@@ -105,13 +104,13 @@ class _HashBase implements Hash {
   Uint8List asBytes() => bytes;
 
   @override
-  BigInteger asBigInteger() => new BigInteger.fromBytes(1, asBytes());
+  BigInt asBigInteger() => CryptoUtils.bytesToBigInt(asBytes());
 
   @override
   Uint8List copyAsBytes() => new Uint8List.fromList(_content);
 
   @override
-  BigInteger copyAsBigInteger() => new BigInteger.fromBytes(1, copyAsBytes());
+  BigInt copyAsBigInteger() => CryptoUtils.bytesToBigInt(copyAsBytes());
 
   @override
   String toHex() => CryptoUtils.bytesToHex(_content);

--- a/lib/src/hash/fixed-sized-hashes.dart
+++ b/lib/src/hash/fixed-sized-hashes.dart
@@ -3,7 +3,7 @@ part of cryptoutils.hash;
 class _FixedSizeHash extends _HashBase {
   _FixedSizeHash(dynamic content, int supposedSize) : super(content) {
     // pad the bytes if content was a small BigInteger
-    if (content is BigInteger && _content.length < supposedSize) {
+    if (content is! BigInt && _content.length < supposedSize) {
       Uint8List newBytes = new Uint8List(supposedSize)
         ..setRange(supposedSize - _content.length, supposedSize, _content);
       _content = newBytes;

--- a/lib/src/hash/fixed-sized-hashes.dart
+++ b/lib/src/hash/fixed-sized-hashes.dart
@@ -3,7 +3,7 @@ part of cryptoutils.hash;
 class _FixedSizeHash extends _HashBase {
   _FixedSizeHash(dynamic content, int supposedSize) : super(content) {
     // pad the bytes if content was a small BigInteger
-    if (content is! BigInt && _content.length < supposedSize) {
+    if (_content.length < supposedSize) {
       Uint8List newBytes = new Uint8List(supposedSize)
         ..setRange(supposedSize - _content.length, supposedSize, _content);
       _content = newBytes;

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -75,4 +75,81 @@ abstract class CryptoUtils {
    */
   static Uint8List base64StringToBytes(String input) =>
       new Base64Decoder().convert(input);
+
+  static BigInt bytesToBigInt(List s) {
+    if (s == null || s.length == 0) {
+      return BigInt.zero;
+    }
+
+    int v = 0;
+    for (int byte in s) {
+      v = (v << 8) | (byte & 0xFF);
+    }
+
+    return BigInt.from(v);
+  }
+
+  /**
+   * convert to bigendian byte array [List]
+   */
+  static List<int> bigIntToByteArray(BigInt data) {
+    String str;
+    bool neg = false;
+    if (data < BigInt.zero) {
+      str = (~data).toRadixString(16);
+      neg = true;
+    } else {
+      str = data.toRadixString(16);
+    }
+    int p = 0;
+    int len = str.length;
+
+    int blen = (len + 1) ~/ 2;
+    int boff = 0;
+    List bytes;
+    if (neg) {
+      if (len & 1 == 1) {
+        p = -1;
+      }
+      int byte0 = ~int.parse(str.substring(0, p + 2), radix: 16);
+      if (byte0 < -128) byte0 += 256;
+      if (byte0 >= 0) {
+        boff = 1;
+        bytes = new List<int>(blen + 1);
+        bytes[0] = -1;
+        bytes[1] = byte0;
+      } else {
+        bytes = new List<int>(blen);
+        bytes[0] = byte0;
+      }
+      for (int i = 1; i < blen; ++i) {
+        int byte = ~int.parse(str.substring(p + (i << 1), p + (i << 1) + 2),
+            radix: 16);
+        if (byte < -128) byte += 256;
+        bytes[i + boff] = byte;
+      }
+    } else {
+      if (len & 1 == 1) {
+        p = -1;
+      }
+      int byte0 = int.parse(str.substring(0, p + 2), radix: 16);
+      if (byte0 > 127) byte0 -= 256;
+      if (byte0 < 0) {
+        boff = 1;
+        bytes = new List<int>(blen + 1);
+        bytes[0] = 0;
+        bytes[1] = byte0;
+      } else {
+        bytes = new List<int>(blen);
+        bytes[0] = byte0;
+      }
+      for (int i = 1; i < blen; ++i) {
+        int byte =
+        int.parse(str.substring(p + (i << 1), p + (i << 1) + 2), radix: 16);
+        if (byte > 127) byte -= 256;
+        bytes[i + boff] = byte;
+      }
+    }
+    return bytes;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,6 @@ author: Steven Roose <stevenroose@gmail.com>
 description: A crypto utility library.
 homepage: https://github.com/stevenroose/dart-cryptoutils
 dependencies:
-  bignum: ">=0.1.0 <0.2.0"
   collection: ">=1.1.1 <2.0.0"
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,8 @@ version: 0.3.0
 author: Steven Roose <stevenroose@gmail.com>
 description: A crypto utility library.
 homepage: https://github.com/stevenroose/dart-cryptoutils
+environment:
+  sdk: '>=2.0.0 <3.0.0'
 dependencies:
   collection: ">=1.1.1 <2.0.0"
 

--- a/test/bigint/bigint-utils_test.dart
+++ b/test/bigint/bigint-utils_test.dart
@@ -1,0 +1,39 @@
+library cryptoutils.test.bigintutils;
+
+import "package:test/test.dart";
+
+import 'dart:math' as Mathx;
+
+import "package:cryptoutils/cryptoutils.dart";
+
+bool TEST_EXTRA_LARGE = true;
+run_sequence(t) {
+  if (TEST_EXTRA_LARGE) {
+    for (int i = 0; i < 100; i++) {
+      t();
+    }
+  } else {
+    t();
+  }
+}
+
+void main() {
+  group("bigint.byte-array-conversion", () {
+    test("byteArrayConv", () {
+      // from dart-bignum
+      // https://github.com/dartist/dart-bignum/blob/7966a5a021072db14c757b81b1c24569050e9a39/test/test_big_integer_dartvm.dart#L341
+      Mathx.Random rnd = new Mathx.Random();
+      t() {
+        BigInt x = BigInt.parse(rnd.nextInt(100000000).toRadixString(16), radix: 16);
+        if (x == BigInt.zero) {
+          x = x + BigInt.one;
+        }
+
+        BigInt y = CryptoUtils.bytesToBigInt(CryptoUtils.bigIntToByteArray(x));
+        expect(x.toString(), equals(y.toString()));
+      };
+
+      run_sequence(t);
+    });
+  });
+}

--- a/test/hash/fixed-sized-hashes_test.dart
+++ b/test/hash/fixed-sized-hashes_test.dart
@@ -3,10 +3,9 @@ library cryptoutils.test.fixedsizedhashes;
 import "package:test/test.dart";
 
 import "package:cryptoutils/cryptoutils.dart";
-import "package:bignum/bignum.dart";
 
 void _testBigInteger() {
-  Hash160 hash = new Hash160(BigInteger.ONE);
+  Hash160 hash = new Hash160(BigInt.one);
   expect(hash.lengthInBytes, equals(20));
 }
 


### PR DESCRIPTION
Hi @stevenroose, 

I just started learning Dart and am still a total noob, but I took a shot at solving the issue #3 and it appears to have solved the problem for me. 

I am using this package as a dependency for [http_auth](https://github.com/marcoesposito1988/http_auth), and using this version it passes all my tests for HTTP Digest authentication (which uses SHA heavily).

So I thought could it be useful or inspiring, at least as an example of how this should NOT be done 😅  please feel also free to just take the best parts (if any) and close the merge request. 