### PR TITLE
Removed implementation of TypedData due to unnecessary change to dart…

### DIFF
--- a/lib/hash.dart
+++ b/lib/hash.dart
@@ -12,7 +12,7 @@ part "src/hash/fixed-sized-hashes.dart";
  *
  * Constructors take either List<int>'s or Strings.
  */
-abstract class Hash implements TypedData {
+abstract class Hash {
   /**
    * Create a new Hash instance.
    */


### PR DESCRIPTION
Removed `implements TypedData` from hast.dart to make it compatible with the changes to dart (https://github.com/dart-lang/sdk/issues/45115).